### PR TITLE
Jmnds Tutorials Readme for Kinetic

### DIFF
--- a/jmdns_tutorials/README.md
+++ b/jmdns_tutorials/README.md
@@ -1,1 +1,40 @@
-For instructions, see [the zerconf_jmdns_suite package ROS wiki](http://wiki.ros.org/zeroconf_jmdns_suite).
+# Jmnds Tutorials
+
+There are three demo programs. These are useful for quickly testing or demonstrating the jmdns zeroconf capability. 
+For instructions on how to use the jmdns library in a similar way to these were written, see [the zerconf_jmdns_suite package ROS wiki](http://wiki.ros.org/zeroconf_jmdns_suite/Tutorials).
+
+**Publishing**
+
+Start listening in one shell:
+
+```
+> avahi-browse _ros-master._tcp
+```
+
+And execute the publisher in another shell:
+
+```
+./build/install/jmdns_tutorials/bin/jmdns_tutorials --publisher
+```
+
+**Discovery - Polling**
+
+Start publishing in one shell:
+
+```
+> avahi-publish -s DudeMaster _ros-master._tcp 8882
+```
+
+And execute polling discovery in another (it will print out the discovered list every second):
+
+```
+./build/install/jmdns_tutorials/bin/jmdns_tutorials --polling
+```
+
+**Discovery - Callback**
+
+As above, but start the discovery handler:
+
+```
+./build/install/jmdns_tutorials/bin/jmdns_tutorials --polling
+```

--- a/jmdns_tutorials/README.md
+++ b/jmdns_tutorials/README.md
@@ -1,7 +1,7 @@
 # Jmnds Tutorials
 
 There are three demo programs. These are useful for quickly testing or demonstrating the jmdns zeroconf capability. 
-For instructions on how to use the jmdns library in a similar way to these were written, see [the zerconf_jmdns_suite package ROS wiki](http://wiki.ros.org/zeroconf_jmdns_suite/Tutorials).
+For instructions on how to use the jmdns library in a similar way to these were written, see [the zeroconf_jmdns_suite Tutorials](http://wiki.ros.org/zeroconf_jmdns_suite/Tutorials) on the ROS wiki.
 
 **Publishing**
 


### PR DESCRIPTION
Updated the readme with the dev notes on how to run the binaries - this is useful for very quick testing of the zeroconf capabilities (impossible to remember if you only come back occasionally).

The pointer to the ros wiki is useful for users of the library - thanks for linking that! I've now got it pointing to the tutorials page and have updated the ROS wiki so the tutorials are comprehensible and linked correctly for kinetic.